### PR TITLE
python3.8 → python3 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ submodules:
 
 split:
 	rm -rf $(DATA_DIRS) $(ASM_DIRS)
-	python3.8 ./tools/splat/split.py --rom baserom.z64 --outdir . splat.yaml
+	python3 ./tools/splat/split.py --rom baserom.z64 --outdir . splat.yaml
 
 setup: clean submodules split
 	


### PR DESCRIPTION
I think it's a typo. "python3" will assure a better compatibility across distributions (python is already at version 3.9 on Arch)