### PR TITLE
Deobfuscate `TActor.ptr0x38` field

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -18,7 +18,7 @@ typedef float Vec4[4];
 //prelimnary, lots of unknowns
 //contains pointer-to-own-type fields, so `typedef struct _TActor {`
 //must be used instead of `typedef struct {`
-typedef struct _TActor {
+typedef struct TActor {
 /*0000*/  s16 rotation[3]; //why short?
 /*0006*/  s16 unk0x6;
 /*0008*/  float scale;
@@ -27,7 +27,7 @@ typedef struct _TActor {
 	Vec3f speed;
 	void* ptr0x30;
 	UNK_TYPE_32 unk0x34;
-	struct _TActor* linkedActor;
+	struct TActor* linkedActor;
 	u8 unk0x3c[3];
 	UNK_TYPE_16 unk0x44;
 	UNK_TYPE_16 unk0x46;

--- a/include/variables.h
+++ b/include/variables.h
@@ -16,7 +16,9 @@ typedef float Vec3[3];
 typedef float Vec4[4];
 
 //prelimnary, lots of unknowns
-typedef struct {
+//contains pointer-to-own-type fields, so `typedef struct TActor {`
+//must be used instead of `typedef struct {`
+typedef struct TActor {
 /*0000*/  s16 rotation[3]; //why short?
 /*0006*/  s16 unk0x6;
 /*0008*/  float scale;
@@ -25,7 +27,7 @@ typedef struct {
 	Vec3f speed;
 	void* ptr0x30;
 	UNK_TYPE_32 unk0x34;
-	void* ptr0x38;
+	TActor* linkedActor;
 	u8 unk0x3c[3];
 	UNK_TYPE_16 unk0x44;
 	UNK_TYPE_16 unk0x46;

--- a/include/variables.h
+++ b/include/variables.h
@@ -16,9 +16,9 @@ typedef float Vec3[3];
 typedef float Vec4[4];
 
 //prelimnary, lots of unknowns
-//contains pointer-to-own-type fields, so `typedef struct TActor {`
+//contains pointer-to-own-type fields, so `typedef struct _TActor {`
 //must be used instead of `typedef struct {`
-typedef struct TActor {
+typedef struct _TActor {
 /*0000*/  s16 rotation[3]; //why short?
 /*0006*/  s16 unk0x6;
 /*0008*/  float scale;
@@ -27,7 +27,7 @@ typedef struct TActor {
 	Vec3f speed;
 	void* ptr0x30;
 	UNK_TYPE_32 unk0x34;
-	TActor* linkedActor;
+	struct _TActor* linkedActor;
 	u8 unk0x3c[3];
 	UNK_TYPE_16 unk0x44;
 	UNK_TYPE_16 unk0x46;


### PR DESCRIPTION
This was figured out by the examining the output of the dump-actor-lists-to-JSON script I posted on the `coding-reverse-engineering` Discord channel yesterday (I'm `ssds` there, to be clear).

Specifically, for example, if you look at this partial snippet from an entry for Krystal:

```json
"TActor_0": {
  "name": "Krystal",
  "address": "0x805F8018",
  "fields": {
    "rotation": [-31233, 0, 0],
    "unk0x6": 2,
    "scale": 0.0494999997317791,
    "position": [971.0263671875, 431.73724365234375, 17771.861328125],
    "positionMirror": [971.0263671875, 431.73724365234375, 17771.861328125],
    "speed": [0, 0, 0],
    "ptr0x30": "0x00000000",
    "unk0x34": 65535,
    "ptr0x38": "0x80101C18",
```
The `ptr0x38` field for her there is the address of another `TActor` object for which the relevant snippet looks like this:

```json
"TActor_2": {
  "name": "TriggerArea",
  "address": "0x80101C18",
  "fields": {
    "rotation": [21760, 0, 0],
    "unk0x6": 2,
    "scale": 1,
    "position": [1151.096435546875, 367.7933044433594, 17801.52734375],
    "positionMirror": [1151.096435546875, 367.7933044433594, 17801.52734375],
    "speed": [0, 0, 0],
    "ptr0x30": "0x00000000",
    "unk0x34": 65280,
    "ptr0x38": "0x800F9950",
```

which in turn has a `ptr0x38` field set to the address of a third `TActor` object for which the relevant snippet looks like this:

```json
"TActor_3": {
  "name": "TriggerPlane",
  "address": "0x800F9950",
  "fields": {
    "rotation": [-8192, 0, 0],
    "unk0x6": 2,
    "scale": 1.875,
    "position": [1129.2900390625, 348.3329162597656, 17473.705078125],
    "positionMirror": [1129.2900390625, 348.3329162597656, 17473.705078125],
    "speed": [0, 0, 0],
    "ptr0x30": "0x00000000",
    "unk0x34": 65280,
    "ptr0x38": "0x00000000",
```

So in that case, it goes Krystal -> TriggerArea -> TriggerPlane, with TriggerPlane being "the end of the road" so to speak as it does not have a meaningfully initialized `ptr0x38` field.