### PR TITLE
header.bin rewritten as an asm file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ submodules:
 split:
 	rm -rf $(DATA_DIRS) $(ASM_DIRS)
 	python3 ./tools/splat/split.py --rom baserom.z64 --outdir . splat.yaml
+	rm -rf bin/header.bin
+	cp headerasmtemp/header.s asm/header.s
+	rm -rf headerasmtemp/
+# delete header.bin as an ASM replacement has been written; TODO: someone find a better way to use header.s instead of the splat bin
 
 setup: baseverify clean submodules split
 	

--- a/headerasmtemp/header.s
+++ b/headerasmtemp/header.s
@@ -1,0 +1,24 @@
+/*
+ * Dinosaur Planet ROM Header
+ */
+
+.byte  0x80, 0x37, 0x12, 0x40   /* PI BSD Domain 1 register */
+.word  0x0000000F               /* Clockrate setting*/
+.word  romMain                  /* Entrypoint */
+
+/* Revision */
+    .word  0x00001449
+
+.word  0xD0F6A741               /* Checksum 1 */
+.word  0x7D57761E               /* Checksum 2 */
+.word  0x00000000               /* Unknown */
+.word  0x00000000               /* Unknown */
+.ascii "DINO PLANET         "   /* Internal ROM name */
+.word  0x00000000               /* Unknown */
+.word  0x0000004E               /* 1st letter of cartridge ID (N) [I wonder if this can replaced with .ascii "N"?] */
+.ascii "DP"                     /* Next 2 letters of cartridge ID */
+
+/* Region */
+.ascii "E"                  /* 4th letter of cartridge ID indicates game region, E = NTSC-U (North America) */
+
+.byte  0x00                 /* Version number, some games use this, DP's ROM header leaves it blank. */


### PR DESCRIPTION
Rewrote the header.bin file as assembly, gives OK, however, I have no clue how to use splat, so I dud some makefile jankiness to remove header.bin after make setup and copy in header.s, someone can likely do better than me on that part.
![image](https://user-images.githubusercontent.com/35207254/142699942-5f99fa79-1c03-4dec-af69-70b074f74f5a.png)
EDIT: seems my jank fix busted the checking system
