### PR TITLE
Add required dependencies for progress.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ python-Levenshtein
 python-ranges
 textwrap3
 watchdog
+GitPython
+colour


### PR DESCRIPTION
I noticed progress.py didn't have the proper dependencies listed in requirements.txt. I added them so that they are installed during first-time setup.