### PR TITLE
Match rest of crash.c + a DLL system function

### DIFF
--- a/include/PR/os.h
+++ b/include/PR/os.h
@@ -71,6 +71,7 @@ typedef struct OSThread_s {
 	OSId			id;		/* id for debugging */
 	int			fp;		/* thread has used fp unit */
 	__OSThreadContext	context;	/* register/interrupt mask */
+	u8			unk0x1b0[128]; /* NOTE: Not from the original os.h! */
 } OSThread;
 
 typedef u32 OSEvent;

--- a/include/PR/sched.h
+++ b/include/PR/sched.h
@@ -100,7 +100,6 @@ typedef struct {
     OSMesgQueue cmdQ;
     OSMesg      cmdMsgBuf[OS_SC_MAX_MESGS];
     OSThread    thread;
-    u8          unk0x25c[128]; /* NOTE: Not from the original sched.h! */
     OSScClient  *clientList;
     OSScTask    *audioListHead;
     OSScTask    *gfxListHead;

--- a/include/functions.h
+++ b/include/functions.h
@@ -30,4 +30,6 @@ void stop_alSyn_thread();
 
 void func_80060B94(Gfx**);
 
+OSSched *get_ossched(void);
+
 #endif //_FUNCTIONS_H

--- a/include/sys/crash.h
+++ b/include/sys/crash.h
@@ -2,15 +2,73 @@
  */
 #ifndef _SYS_CRASH_H
 #define _SYS_CRASH_H
+
 #include "PR/ultratypes.h"
 
-//use for crash screens
-struct ErrString{
+// used for crash screens
+struct ErrString {
 	u32 code1;
 	u32 code2;
 	char* text;
 };
 
+// Length of gCrashMesgQueueBuffer
+#define CRASH_MESG_QUEUE_BUFFER_LENGTH 1
+
+#define CRASH_ASSET_THREAD_COPY ((OSThread *)0x807FF000)
+#define CRASH_MAIN_THREAD_COPY ((OSThread *)0x807FF230)
+#define CRASH_DLL_LIST_COPY ((CrashedDlls *)0x807FF460)
+
+typedef struct {
+    /*0x0*/  DLLInst* loadedDllList;
+    /*0x4*/  s32 loadedDllCount;
+    /*0x8*/  u8 loaded; // Whether any DLLs are actually stored here.
+} CrashedDlls;
+
+typedef struct {
+    /*0x0*/  OSThread *threads[2];
+} CrashThreadCopies;
+
+/**
+ * Holds a list of DLLs that were previously running before the last NMI reset.
+ */
+CrashedDlls *gCrashDllListCopy = CRASH_DLL_LIST_COPY;
+/**
+ * Holds copies of the main thread and asset thread respectively from before
+ * the last NMI reset.
+ */
+CrashThreadCopies gCrashThreadCopies = { { CRASH_MAIN_THREAD_COPY, CRASH_ASSET_THREAD_COPY } };
+
+// Note: Unsure of actual stack size
+extern u8 gCrashThreadStack[OS_MIN_STACKSIZE];
+extern OSThread gCrashThread;
+
+extern OSScClient gCrashScClient;
+
+extern OSMesg gCrashMesgQueueBuffer[CRASH_MESG_QUEUE_BUFFER_LENGTH];
+extern OSMesgQueue gCrashMesgQueue;
+
+extern OSScMsg gCrashScMsg;
+
 void start_crash_thread(OSSched* scheduler);
+
+void crash_thread_entry(void *arg);
+
+/**
+ * Stops all active application threads (those with priorities between 1 and OS_PRIORITY_APPMAX).
+ *
+ * Identical to stop_active_app_threads.
+ */
+void stop_active_app_threads_2();
+
+/**
+ * Runs from the crash thread when pre-NMI occurs.
+ * 
+ * - Copies the main thread and asset thread.
+ * - Copies the list of currently loaded DLLs.
+ * - Returns the ID of the DLL currently being executed by the main thread,
+ *   or -1 if the main thread is not executing a DLL.
+ */
+u32 crash_nmi_handler();
 
 #endif //_SYS_CRASH_H

--- a/include/sys/crash.h
+++ b/include/sys/crash.h
@@ -29,16 +29,6 @@ typedef struct {
     /*0x0*/  OSThread *threads[2];
 } CrashThreadCopies;
 
-/**
- * Holds a list of DLLs that were previously running before the last NMI reset.
- */
-CrashedDlls *gCrashDllListCopy = CRASH_DLL_LIST_COPY;
-/**
- * Holds copies of the main thread and asset thread respectively from before
- * the last NMI reset.
- */
-CrashThreadCopies gCrashThreadCopies = { { CRASH_MAIN_THREAD_COPY, CRASH_ASSET_THREAD_COPY } };
-
 // Note: Unsure of actual stack size
 extern u8 gCrashThreadStack[OS_MIN_STACKSIZE];
 extern OSThread gCrashThread;

--- a/include/sys/crash.h
+++ b/include/sys/crash.h
@@ -9,7 +9,7 @@
 struct ErrString {
 	u32 code1;
 	u32 code2;
-	char* text;
+	char *text;
 };
 
 // Length of gCrashMesgQueueBuffer
@@ -20,7 +20,7 @@ struct ErrString {
 #define CRASH_DLL_LIST_COPY ((CrashedDlls *)0x807FF460)
 
 typedef struct {
-    /*0x0*/  DLLInst* loadedDllList;
+    /*0x0*/  DLLInst *loadedDllList;
     /*0x4*/  s32 loadedDllCount;
     /*0x8*/  u8 loaded; // Whether any DLLs are actually stored here.
 } CrashedDlls;
@@ -50,7 +50,7 @@ extern OSMesgQueue gCrashMesgQueue;
 
 extern OSScMsg gCrashScMsg;
 
-void start_crash_thread(OSSched* scheduler);
+void start_crash_thread(OSSched *scheduler);
 
 void crash_thread_entry(void *arg);
 

--- a/include/sys/dll.h
+++ b/include/sys/dll.h
@@ -140,4 +140,13 @@ extern DLLInst* gLoadedDLLList;
 extern s32 gLoadedDLLCount;
 extern DLLTab * gFile_DLLS_TAB;
 
+/**
+ * Returns the ID of the DLL that the given program counter is executing within, 
+ * or -1 if the PC is not within a DLL.
+ * 
+ * start and end will also be set to pointers to the start and end 
+ * of the DLL's body respectively.
+ */
+u32 find_executing_dll(u32 pc, u32 **start, u32 **end);
+
 #endif //_SYS_DLL_H

--- a/include/sys/dll.h
+++ b/include/sys/dll.h
@@ -148,6 +148,6 @@ extern DLLTab * gFile_DLLS_TAB;
  * of the DLL's body respectively.
  */
 u32 find_executing_dll(u32 pc, u32 **start, u32 **end);
-DLLInst * get_loaded_dlls(u32 * arg0);
+DLLInst *get_loaded_dlls(u32 *arg0);
 
 #endif //_SYS_DLL_H

--- a/include/sys/dll.h
+++ b/include/sys/dll.h
@@ -148,5 +148,6 @@ extern DLLTab * gFile_DLLS_TAB;
  * of the DLL's body respectively.
  */
 u32 find_executing_dll(u32 pc, u32 **start, u32 **end);
+DLLInst * get_loaded_dlls(u32 * arg0);
 
 #endif //_SYS_DLL_H

--- a/include/sys/exception.h
+++ b/include/sys/exception.h
@@ -44,7 +44,7 @@ extern s32 gSomeCFileInts[C_FILE_LABELS_LENGTH];
  */
 void stop_active_app_threads();
 
-void some_crash_print(OSThread** threads, s32 count, s32 offset);
+void some_crash_print(OSThread **threads, s32 count, s32 offset);
 
 /**
  * - Sets D_800937F0 to 0

--- a/include/sys/exception.h
+++ b/include/sys/exception.h
@@ -44,7 +44,7 @@ extern s32 gSomeCFileInts[C_FILE_LABELS_LENGTH];
  */
 void stop_active_app_threads();
 
-void some_crash_print(OSThread**, int, int);
+void some_crash_print(OSThread** threads, s32 count, s32 offset);
 
 /**
  * - Sets D_800937F0 to 0

--- a/splat.yaml
+++ b/splat.yaml
@@ -218,6 +218,10 @@ segments:
     # data/rodata for this section
     - [0x8A350, bin]
 
+    - [0x92370, .data, crash]
+
+    - [0x92380, bin]
+
     - [0x99CA0, .rodata, queue]
     - [0x99D10, .rodata, main]
 

--- a/src/crash.c
+++ b/src/crash.c
@@ -1,6 +1,16 @@
 #include "common.h"
 #include <PR/os_internal.h>
 
+/**
+ * Holds a list of DLLs that were previously running before the last NMI reset.
+ */
+CrashedDlls *gCrashDllListCopy = CRASH_DLL_LIST_COPY;
+/**
+ * Holds copies of the main thread and asset thread respectively from before
+ * the last NMI reset.
+ */
+CrashThreadCopies gCrashThreadCopies = { { CRASH_MAIN_THREAD_COPY, CRASH_ASSET_THREAD_COPY } };
+
 void start_crash_thread(OSSched *scheduler) {
     s32 videoMode = OS_VI_PAL_LPN1;
 

--- a/src/crash.c
+++ b/src/crash.c
@@ -1,7 +1,7 @@
 #include "common.h"
 #include <PR/os_internal.h>
 
-void start_crash_thread(OSSched* scheduler) {
+void start_crash_thread(OSSched *scheduler) {
     s32 videoMode = OS_VI_PAL_LPN1;
 
     if (osResetType == 1 && gCrashDllListCopy->loaded == TRUE) {

--- a/src/dll.c
+++ b/src/dll.c
@@ -58,7 +58,6 @@ void replace_loaded_dll_list(DLLInst arg0[], s32 arg1) {
     gLoadedDLLList = arg0;
 }
 
-DLLInst * get_loaded_dlls(u32 * arg0);
 DLLInst * get_loaded_dlls(u32 * arg0) {
     *arg0 = gLoadedDLLCount;
     return gLoadedDLLList;

--- a/src/dll.c
+++ b/src/dll.c
@@ -23,7 +23,35 @@ void init_dll_system(void)
     }
 }
 
-#pragma GLOBAL_ASM("asm/nonmatchings/dll/func_8000BD1C.s")
+u32 find_executing_dll(u32 pc, u32 **start, u32 **end) {
+    s32 i;
+
+    for (i = 0; i < gLoadedDLLCount; i++) {
+        if (gLoadedDLLList[i].id == -1) {
+            continue;
+        }
+        
+        // Get start and end of the full DLL
+        *start = gLoadedDLLList[i].exports - 6;
+        *end = gLoadedDLLList[i].end;
+
+        if ((s32)*start > (s32)pc || (s32)pc > (s32)*end) {
+            // PC is not within the DLL
+        } else {
+            // PC is within the DLL
+
+            // Set start to the beginning of executable DLL code
+            // *start = headerSize + startOfFullDLL
+            *start = **start + (u32)*start;
+
+            // Return ID of found DLL
+            return gLoadedDLLList[i].id;
+        }
+    }
+
+    // PC is not executing within any loaded DLL
+    return -1;
+}
 
 void replace_loaded_dll_list(DLLInst arg0[], s32 arg1) {
     gLoadedDLLCount = arg1;

--- a/symbol_addrs.txt
+++ b/symbol_addrs.txt
@@ -1188,8 +1188,13 @@ handle_joystick_deadzone = 0x800111BC; // type:func
 get_joystick_x = 0x80010F78; // type:func
 get_joystick_y = 0x8001107C; // type:func
 
+gCrashDllListCopy = 0x80091770; // type:data
+gCrashThreadCopies = 0x80091774; // type:data
 gCrashMesgQueueBuffer = 0x800B3754; // type:data size:0x4
+gCrashScClient = 0x800B3748; // type:data
+gCrashScMsg = 0x800B3770; // type:data
 stop_active_app_threads_2 = 0x80037610; // type:func
+crash_nmi_handler = 0x80037678; // type:func
 
 gStrAudioTask = 0x8009a020; // type:data
 gStrGameTask = 0x8009a030; // type:data

--- a/symbol_addrs.txt
+++ b/symbol_addrs.txt
@@ -885,6 +885,7 @@ set_menu_page = 0x8000f404; // type:func
 do_set_menu_page = 0x8000f47c; // type:func
 gActiveMenuDLL = 0x800a7d54; // type:data size:0x4
 
+find_executing_dll = 0x8000BD1C; // type:func
 dll_load_deferred = 0x8000be04; // type:func
 dll_load = 0x8000be78; // type:func
 dll_load_from_tab = 0x8000c3cc; // type:func


### PR DESCRIPTION
- Matches remaining functions in crash.c
- Fixes OSThread and OSSched definitions (there was 128 unknown bytes defined in OSSched that were actually part of the OSThread field before it)
- Matched find_executing_dll (aka func_8000BD1C, which is called by a crash function)