### PR TITLE
Small tool updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN pip3 install -r requirements.txt
 # Symlink dino.py
 RUN ln -s /dino/dino.py /usr/local/bin/dino
 
+# Set up user
+ARG login=sabre
+ARG uid=1000
+RUN adduser --system --uid $uid --group $login
+
 # Set entrypoint
-RUN echo "#! /bin/bash\nexec \"\$@\"" > /entrypoint.sh && chmod +x /entrypoint.sh
+RUN echo "#!/bin/bash\nexec \"\$@\"" > /entrypoint.sh && chmod +x /entrypoint.sh
+USER $uid
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ If you prefer to develop inside of a Docker container instead of installing ever
 
 Example usage:
 ```bash
-# Create container
-docker build -t dpdecomp .
+# Create image
+docker build -t dpdecomp --build-arg login=$USER --build-arg uid=$UID .
 
 # Enter a bash prompt
 docker run --rm -it -v $(pwd):/dino dpdecomp bash

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -4,5 +4,5 @@ def apply(config, args):
     config['baseimg'] = 'baserom.z64'
     config['myimg'] = 'build/dino.z64'
     config['mapfile'] = 'build/dino.map'
-    config['source_directories'] = ['.']
+    config['source_directories'] = ['src', 'include']
     config['make_command'] = ['ninja']

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -246,6 +246,8 @@ f32 vec3_normalize(Vec3f *a0) {
 
 This looks significantly better already (and compiles)! Let's check our progress so far by diffing our implementation against the original ROM. We can do this by building the ROM (`./dino.py build`) and then running diff on the function's symbol (`./dino.py diff vec3_normalize`). Looks like everything matches except for one instruction: `lui at,0x3f80`, which from our implementation is currently `lui at,0x4e7e`. If we trace this instruction back to the C code, we can see it's from the line `f18 = 0x3f800000;` Let's fix it.
 
+> Tip: When running `diff` consider passing the flags `-m -o -w` (or just `-mow`). This will tell diff to run build first, compare object files (to display symbol names), and watch the source file for changes and auto re-build, respectively.
+
 Looking back at the assembly, we can see these two instructions:
 ```
 lui     at,0x3f80

--- a/splat.yaml
+++ b/splat.yaml
@@ -3,14 +3,16 @@ crc1: D0F6A741
 crc2: 7D57761E
 options:
   basename: dino
-  find_file_boundaries: yes
   compiler: IDO
-  mnemonic_ljust: 11
   platform: n64
-  base_path: ./
+  find_file_boundaries: yes
   target_path: baserom.z64
+  base_path: ./
   asset_path: bin
+  asm_path: asm
+  src_path: src
   symbol_addrs_path: ./symbol_addrs.txt
+  mnemonic_ljust: 11
   # Use .o instead of .bin.o suffix in linker script
   # TODO: probably should remove this
   o_as_suffix: True


### PR DESCRIPTION
- Prevent Dockerfile usage creating files as root
- Small config clean up
- dino.py now generates `expected/`, which contains matching object files for each source. Needed by diff.py to diff by object file.
- Add `--use-cache` flag for `./dino.py extract`
- Fix `./dino.py diff` not passing arguments to diff.py correctly
- `./dino.py extract` now automatically re-configures the build script