### PR TITLE
More core matches

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -3456,9 +3456,6 @@ void blockSetupDLGroups(Block *block) {
     }
 }
 
-#ifndef NON_MATCHING
-#pragma GLOBAL_ASM("asm/nonmatchings/map/blockSetupVertices.s")
-#else
 void blockSetupVertices(Block *block) {
     s32 i;
     BlockShape *shape;
@@ -3481,7 +3478,6 @@ void blockSetupVertices(Block *block) {
         shape = &block->shapes[i];
         pverts = shape->vtxBase + block->vertices;
         ptri = shape->triBase + block->encodedTris;
-        if ((s32)verts) {}
         ptriend = &block->encodedTris[shape[1].triBase];
 
         while (ptri < ptriend)
@@ -3519,20 +3515,19 @@ void blockSetupVertices(Block *block) {
             iny = ny * 8191.0f;
             inz = nz * 8191.0f;
 
-            ptri->d0 |= inx << 18;
+            ptri->d0 |= (inx & 0x3fff) << 18;
             ptri->d1 |= (iny & 0x3fff) << 4;
-            ptri->d1 |= inz << 18;
+            ptri->d1 |= (inz & 0x3fff) << 18;
             ptri->d1 |= 0x1;
             ptri++;
         }
 
         shape = &block->shapes[i];
-        if (shape->flags & RENDER_UNK10) {
+        if (shape->flags & RENDER_DECAL) {
             shape->flags |= RENDER_UNK800;
         }
     }
 }
-#endif
 
 void blockFree(s32 blockIndex) {
     Block *block;

--- a/src/model.c
+++ b/src/model.c
@@ -732,12 +732,7 @@ Animation* modLoadAnim(s16 animID, s16 modAnimID, AmapPlusAnimation* amap, Model
 }
 
 // official name: modLoadAnimActual
-#ifndef NON_MATCHING
-Animation* modLoadAnimActual(s16 animId, s16 modanimId, AmapPlusAnimation* anim, Model* model);
-#pragma GLOBAL_ASM("asm/nonmatchings/model/modLoadAnimActual.s")
-#else
 // https://decomp.me/scratch/j3qkH
-
 Animation* modLoadAnimActual(s16 animId, s16 modanimId, AmapPlusAnimation* anim, Model* model) {
     s32 i;
     s32 sp28;
@@ -785,12 +780,13 @@ Animation* modLoadAnimActual(s16 animId, s16 modanimId, AmapPlusAnimation* anim,
     piRomLoadSection(ANIM_BIN, var_s1, sp24, sp20);
     if (anim != NULL) {
         sp20 = ALIGN8(model->jointCount - 1);
-        piRomLoadSection(AMAP_BIN, anim, model->unk5C + (modanimId * sp20), sp20);
+        sp24 = model->unk5C + (modanimId * sp20);
+        piRomLoadSection(AMAP_BIN, anim, sp24, sp20);
     }
 
     if (anim == NULL) {
         var_s1->referenceCount = 1;
-        if ((sp28 == -1) != 0) {
+        if (sp28 == -1) {
             sp28 = gNumLoadedAnims++;
             if (gNumLoadedAnims == 128) {
                 gNumLoadedAnims--;
@@ -807,8 +803,6 @@ Animation* modLoadAnimActual(s16 animId, s16 modanimId, AmapPlusAnimation* anim,
     if (1) { }
     return var_s1;
 }
-
-#endif
 
 void modFreeAnim(Animation* anim) {
     AnimSlot* slot;

--- a/src/objprint.c
+++ b/src/objprint.c
@@ -41,7 +41,7 @@ u8 BYTE_800b2e23;
 
 void objprint_func_800357B4(Object*, ModelInstance*, Model*);
 ModelInstance *objprintDrawChildModel(Gfx**, Mtx**, Vertex**, Triangle**, Object*, ModelInstance*, MtxF*, MtxF*, Object*, s32, s32);
-void objprint_func_80036890(Object*, s32);
+s32 objprint_func_80036890(Object*, s32);
 void objprint_func_80036058(Object*, Object*, ModelInstance*, Gfx**, Mtx**, Vertex**);
 
 void objprintDrawObject(Gfx** gdl, Mtx** mtxs, Vertex** vtxs, Triangle** tris, Object* obj, s8 visibility) {
@@ -607,12 +607,7 @@ void objprintUpdateLockIconCoords(Object* arg0) {
     }
 }
 
-#ifndef NON_MATCHING
-void objprint_func_80036890(Object* arg0, s32 arg1);
-#pragma GLOBAL_ASM("asm/nonmatchings/objprint/objprint_func_80036890.s")
-#else
-// https://decomp.me/scratch/cjUgO
-void objprint_func_80036890(Object* arg0, s32 arg1) {
+s32 objprint_func_80036890(Object* arg0, s32 arg1) {
     s32 sp6C; // a1
     Gfx* temp_a1_2;
     s32 sp64;
@@ -643,19 +638,23 @@ void objprint_func_80036890(Object* arg0, s32 arg1) {
     s16 var_t2;
     s32 new_var_2;
     u8 *var_s7;
+    Vtx *newp;
+    s32 var_dual;
 
-    var_s6 = arg0->unk70;
-    temp_t5 =  arg0->modelInsts[arg0->modelInstIdx]->model;
-    sp34 = arg0->def->pTextures;
-    sp64 = arg0->def->numAnimatedFrames;
+    newp = arg0->unk70;
+    var_s6 = newp;
     temp_s2 = arg0->modelInsts[arg0->modelInstIdx];
+    temp_t5 = temp_s2->model;
+    var_dual = (s32)arg0->def;
+    sp34 = ((ObjDef*)var_dual)->pTextures;
+    sp64 = ((ObjDef*)var_dual)->numAnimatedFrames;
     for (sp6C = 0; sp6C < sp64; sp6C++, var_s6++) {
         var_t1 = var_s6->n.tc[0];
         var_t2 = var_s6->n.tc[1];
         var_s7 = sp34;
         var_s7 += sp6C << 1;
         var_s7++;
-        for (var_s0 = 0; var_s0 < temp_t5->textureAnimationCount; var_s0++) {
+        for (var_s0 = 0; var_s0 < (var_dual = temp_t5->textureAnimationCount); var_s0++) {
             temp_t4 = &temp_t5->faces[temp_t5->textureAnimations[var_s0].unkB];
             if (temp_t4->tagB == var_s7[0]) {
                 if (temp_t4->materialID != 0xFF) {
@@ -711,9 +710,6 @@ void objprint_func_80036890(Object* arg0, s32 arg1) {
         }
     }
 }
-
-#endif
-
 void objprint_func_80036B78(Object* arg0, Gfx** arg1, Mtx** arg2, s32 arg3) {
     s32 sp6C;
     s32 sp68;

--- a/src/print.c
+++ b/src/print.c
@@ -302,9 +302,6 @@ int sprintf(char *str, const char *fmt, ...) {
     return ret;
 }
 
-#ifndef NON_MATCHING
-#pragma GLOBAL_ASM("asm/nonmatchings/print/vsprintf.s")
-#else
 // https://decomp.me/scratch/fqmpD
 // DKRs (very similar) vsprintf function: https://decomp.me/scratch/ivqHu
 
@@ -392,6 +389,23 @@ int vsprintf(char* s, const char* format, va_list args) {
         s32 v1;
         s32 a0;
         s32 digit;
+        f32 f_f12;
+        char *workend;
+        s32 e_dash;
+        f32 e_f2;
+        f32 e_f16;
+        s32 e_unused;
+        f32 e_spBC;
+        f32 e_f0;
+        s32 e_exponent;
+        s32 e_unused2;
+        f32 f_f14;
+        f32 f_f2;
+        f32 *f_temp;
+        s32 f_dash;
+        s32 f_length;
+        s32 f_v0;
+        f32 f_spBC;
 
         if (*f != '%') {
             /*   This isn't a format spec, so write everything out until the
@@ -584,7 +598,7 @@ int vsprintf(char* s, const char* format, va_list args) {
                 /* Number of base BASE.  */
                 {
                     char *w;
-                    char *workend = &work[sizeof(work) - 1]; // spF8
+                    workend = &work[sizeof(work) - 1]; // spF8
 
                     if (gSprintfSpacingCodes) {
                         outchar(0x84);
@@ -657,15 +671,6 @@ int vsprintf(char* s, const char* format, va_list args) {
             case 'e':
             case 'E':
             {
-                s32 dash; // a3 in this scope
-                f32 f2;
-                f32 f16;
-                s32 unused;
-                f32 spBC;
-                f32 f0;
-                s32 exponent; // spB4 / s3
-                s32 unused2;
-
                 if (gSprintfSpacingCodes) {
                     done++;
                     (*s++) = 0x84;
@@ -677,53 +682,53 @@ int vsprintf(char* s, const char* format, va_list args) {
                 }
 
                 if (is_short) {
-                    nextarg(spBC, f32);
+                    nextarg(e_spBC, f32);
                 } else {
-                    nextarg(spBC, f32);
+                    nextarg(e_spBC, f32);
                 }
 
-                dash = FALSE;
-                if (*((s8*)&spBC) < 0) {
-                    dash = TRUE;
-                    spBC = -spBC;
+                e_dash = FALSE;
+                if (*((s8*)&e_spBC) < 0) {
+                    e_dash = TRUE;
+                    e_spBC = -e_spBC;
                 }
 
-                if (spBC == 0.0f) {
-                    exponent = 0;
-                    f16 = 1.0f;
-                } else if (spBC < 1.0f) {
-                    exponent = 0;
-                    f16 = 1.0f;
-                    while (spBC < f16) {
-                        f16 /= 10.0f;
-                        exponent--;
+                if (e_spBC == 0.0f) {
+                    e_exponent = 0;
+                    e_f16 = 1.0f;
+                } else if (e_spBC < 1.0f) {
+                    e_exponent = 0;
+                    e_f16 = 1.0f;
+                    while (e_spBC < e_f16) {
+                        e_f16 /= 10.0f;
+                        e_exponent--;
                     }
                 }
 
-                if (spBC >= 1.0f) {
-                    exponent = 0;
-                    f16 = 1.0f;
-                    f0 = 10.0f;
-                    while (f0 <= spBC) {
-                        f16 = f0;
-                        f0 *= 10.0f;
-                        exponent++;
+                if (e_spBC >= 1.0f) {
+                    e_exponent = 0;
+                    e_f16 = 1.0f;
+                    e_f0 = 10.0f;
+                    while (e_f0 <= e_spBC) {
+                        e_f16 = e_f0;
+                        e_f0 *= 10.0f;
+                        e_exponent++;
                     }
                 }
 
-                f2 = f16 * 0.5f;
+                e_f2 = e_f16 * 0.5f;
                 for (digit = prec; digit > 0; digit--) {
-                    f2 /= 10.0f;
+                    e_f2 /= 10.0f;
                 }
-                spBC += f2;
+                e_spBC += e_f2;
 
-                f2 = f16 * 10.0f;
-                if (spBC >= f2) {
-                    f16 = f2;
-                    exponent++;
+                e_f2 = e_f16 * 10.0f;
+                if (e_spBC >= e_f2) {
+                    e_f16 = e_f2;
+                    e_exponent++;
                 }
 
-                a0 = (dash || showsign || space) /* a1 */ + prec /* t2 */+ (prec > 0 || alt) /* v1 */ + (exponent >= 100) /* a2 */ + 5;
+                a0 = (e_dash || showsign || space) /* a1 */ + prec /* t2 */+ (prec > 0 || alt) /* v1 */ + (e_exponent >= 100) /* a2 */ + 5;
 
                 if (!left && pad == ' ') {
                     while (width-- > a0) {
@@ -731,7 +736,7 @@ int vsprintf(char* s, const char* format, va_list args) {
                     }
                 }
 
-                if (dash) {
+                if (e_dash) {
                     outchar('-');
                 } else if (showsign) {
                     outchar('+');
@@ -746,12 +751,12 @@ int vsprintf(char* s, const char* format, va_list args) {
                 }
 
                 digit = '0'; // v0
-                while (spBC >= f16) {
-                    spBC -= f16;
+                while (e_spBC >= e_f16) {
+                    e_spBC -= e_f16;
                     digit++;
                 }
                 outchar(digit);
-                f16 /= 10.0f;
+                e_f16 /= 10.0f;
 
                 if (prec > 0 || alt /* s8 */) {
                     outchar('.');
@@ -759,30 +764,32 @@ int vsprintf(char* s, const char* format, va_list args) {
 
                 while (prec > 0) {
                     digit = '0';
-                    while (spBC >= f16) {
-                        spBC -= f16;
+                    while (e_spBC >= e_f16) {
+                        e_spBC -= e_f16;
                         digit++;
                     }
                     outchar(digit);
-                    f16 /= 10.0f;
+                    e_f16 /= 10.0f;
                     prec--;
                 }
 
                 outchar(fc);
 
-                if (exponent < 0) {
-                    exponent = -exponent;
+                if (e_exponent < 0) {
+                    e_exponent = -e_exponent;
                     outchar('-');
                 } else {
+#line 780
                     outchar('+');
+#line 783
                 }
 
-                if (exponent >= 100) {
-                    outchar('0' + (exponent / 100));
+                if (e_exponent >= 100) {
+                    outchar('0' + (e_exponent / 100));
                 }
 
-                outchar('0' + ((exponent / 10) % 10));
-                outchar('0' + (exponent % 10));
+                outchar('0' + ((e_exponent / 10) % 10));
+                outchar('0' + (e_exponent % 10));
 
                 if (left) {
                     while (width-- > a0) {
@@ -796,16 +803,9 @@ int vsprintf(char* s, const char* format, va_list args) {
                 break;
             case 'f':
             {
-                f32 f12 = 1.0f;
-                f32 f14;
-                f32 f2;
-                f32 *temp; // spE4
-                s32 dash; // a3 in this scope, maybe shared with 'e' case?
-                s32 length;
-                s32 v0;
-                f32 spBC;
+                f_f12 = 1.0f;
 
-                dash = FALSE;
+                f_dash = FALSE;
 
                 if (gSprintfSpacingCodes) {
                      outchar(0x84);
@@ -816,49 +816,49 @@ int vsprintf(char* s, const char* format, va_list args) {
                 }
 
                 for (digit = 0; digit < prec; digit++) {
-                    f12 /= 10.0f;
+                    f_f12 /= 10.0f;
                 }
 
                 if (is_short) {
-                    nextarg(temp, f32 *);
-                    spBC = *temp;
+                    nextarg(f_temp, f32 *);
+                    f_spBC = *f_temp;
                 } else {
-                    nextarg(temp, f32 *);
-                    if ((u32)temp < 0x80000000 || (u32)temp >= 0x80800001) {
+                    nextarg(f_temp, f32 *);
+                    if ((u32)f_temp < 0x80000000 || (u32)f_temp >= 0x80800001) {
                         outchar('*');
                         outchar('E');
                         outchar('*');
-                        spBC = 0.0f;
+                        f_spBC = 0.0f;
                     } else {
-                        spBC = *temp;
+                        f_spBC = *f_temp;
                     }
                 }
 
-                if (spBC < 0.0f) {
-                    dash = TRUE;
-                    spBC = -spBC;
+                if (f_spBC < 0.0f) {
+                    f_dash = TRUE;
+                    f_spBC = -f_spBC;
                 }
 
-                spBC += f12 * 0.5f;
+                f_spBC += f_f12 * 0.5f;
 
                 digit = 1;
-                f2 = 1.0f;
-                f14 = 10.0f;
-                while (spBC >= f14) {
-                    f2 = f14;
-                    f14 *= 10.0f;
+                f_f2 = 1.0f;
+                f_f14 = 10.0f;
+                while (f_spBC >= f_f14) {
+                    f_f2 = f_f14;
+                    f_f14 *= 10.0f;
                     digit++;
                 }
 
-                length = (dash || showsign || space) + (prec > 0 || alt) + digit + prec;
+                f_length = (f_dash || showsign || space) + (prec > 0 || alt) + digit + prec;
 
                 if (!left && pad == ' ') {
-                    while (width-- > length) {
+                    while (width-- > f_length) {
                         outchar(pad);
                     }
                 }
 
-                if (dash) {
+                if (f_dash) {
                     outchar('-');
                 } else if (showsign) {
                     outchar('+');
@@ -867,20 +867,20 @@ int vsprintf(char* s, const char* format, va_list args) {
                 }
 
                 if (!left && pad == '0') {
-                    while (width-- > length) {
+                    while (width-- > f_length) {
                         outchar(pad);
                     }
                 }
 
                 do {
                     digit = '0';
-                    while (spBC >= f2) {
-                        spBC -= f2;
+                    while (f_spBC >= f_f2) {
+                        f_spBC -= f_f2;
                         digit++;
                     }
-                    f2 /= 10.0f;
+                    f_f2 /= 10.0f;
                     outchar(digit);
-                } while (f2 >= 1.0f);
+                } while (f_f2 >= 1.0f);
 
                 if (prec > 0 || alt) {
                     outchar('.');
@@ -888,17 +888,17 @@ int vsprintf(char* s, const char* format, va_list args) {
 
                 while (prec > 0) {
                     digit = '0';
-                    while (spBC >= f2) {
-                        spBC -= f2;
+                    while (f_spBC >= f_f2) {
+                        f_spBC -= f_f2;
                         digit++;
                     }
                     outchar(digit);
-                    f2 /= 10.0f;
+                    f_f2 /= 10.0f;
                     prec--;
                 }
 
                 if (left) {
-                    while (width-- > length) {
+                    while (width-- > f_length) {
                         outchar(' ');
                     }
                 }
@@ -922,7 +922,7 @@ int vsprintf(char* s, const char* format, va_list args) {
 
             case 's':
             {
-                static char null[] = "(null)";
+
                 u32 len; // a0
 
                 nextarg(str, char *);
@@ -930,11 +930,11 @@ int vsprintf(char* s, const char* format, va_list args) {
                 // move of a1 into a0 should appear as soon as str is stored into a1
                 if (str == NULL) {
                     /* Write "(null)" if there's space.  */
-                    if (prec == -1 || prec >= (int) sizeof(null) - 1) {
-                        str = null;
-                        len = sizeof(null) - 1;
+                    if (prec == -1 || prec >= (int) sizeof(D_8009AE44) - 1) {
+                        str = (char *)D_8009AE44;
+                        len = sizeof(D_8009AE44) - 1;
                     } else {
-                        str = "";
+                        str = (char *)D_8009AE40;
                         len = 0;
                     }
                 } else {
@@ -975,15 +975,15 @@ int vsprintf(char* s, const char* format, va_list args) {
                     goto number;
                 } else {
                     /* Write "(nil)" for a nil pointer.  */
-                    static char nil[] = "(nil)";
+
                     char *p;
 
-                    width -= sizeof (nil) - 1;
+                    width -= sizeof(D_8009AE4C) - 1;
                     if (!left) {
                         PAD(' ');
                     }
 
-                    grouping = nil;
+                    grouping = (char *)D_8009AE4C;
                     while (*grouping != '\0') {
                         outchar(*grouping++);
                     }
@@ -1027,7 +1027,6 @@ int vsprintf(char* s, const char* format, va_list args) {
     *s = '\0';
     return done;
 }
-#endif
 
 void diPrintfInit(void) {
     u32 fbRes;

--- a/src/rarezip.c
+++ b/src/rarezip.c
@@ -63,29 +63,36 @@ static const char str_80099ed4[] = "rzipUncompress:overflow i:%08x o:%08x %d\n";
 static const char str_80099f00[] = "rzipUncompress(%08x,%08x,...) overflow %d/%d\n";
 
 // official name: rzipUncompress
-#ifndef NON_MATCHING
-#pragma GLOBAL_ASM("asm/nonmatchings/rarezip/rarezipUncompress.s")
-#else
 u8 *rarezipUncompress(u8 *compressedInput, u8 *decompressedOutput, s32 outputSize) {
+    u8 *end = decompressedOutput + outputSize;
+
     rarezip_inflate_input = compressedInput + 5;
     rarezip_inflate_output = decompressedOutput;
     rarezip_num_bits = 0;
     rarezip_bit_buffer = 0;
 
-    if (rarezip_inflate_input){} // fake match
-    
+    if (gHuftTable) {}                  // fake match
+    if (rarezip_inflate_input) {}       // fake match
+    if (rarezip_inflate_input) {}       // fake match
+    if (gHuftTable) {}                  // fake match
+
     while (rarezip_inflate_block() != 0) {
-        
     }
 
+    // The empty tail checks (see str_80099eb0/str_80099ed4/str_80099f00) are
+    // likely the remains of a compiled-out overflow-check debug path.
     if (outputSize != -1) {
-        if (((!decompressedOutput) && (!decompressedOutput)) && (!decompressedOutput)){} // fake match
-        if (compressedInput){} // fake match
+        if ((!decompressedOutput) && (!decompressedOutput) && (!decompressedOutput)) {} // fake match
+        if ((!decompressedOutput) && (!decompressedOutput) && (!decompressedOutput)) {} // fake match
+        if (compressedInput) {}                                                        // fake match
+        if (rarezip_inflate_output > end) {
+        }
+        if (rarezip_inflate_output > end) {
+        }
     }
-    
+
     return decompressedOutput;
 }
-#endif
 
 // official name: huft_build
 void rarezip_huft_build(u32 *b, u32 n, u32 s, u16 *d, u16 *e, huft **t, s32 *m) {

--- a/src/texture.c
+++ b/src/texture.c
@@ -1187,9 +1187,6 @@ void texRenderRestoreState(void) {
 }
 
 // official name: texDPTextureX ?
-#ifndef NON_MATCHING
-#pragma GLOBAL_ASM("asm/nonmatchings/texture/texDPTextureSimple.s")
-#else
 // https://decomp.me/scratch/fpYm1
 s32 texDPTextureSimple(Gfx** gdl, Texture* tex, s32 renderFlags, s32 frameOptions, s32 force, s32 options) {
     s32 pad_sp84;
@@ -1259,7 +1256,7 @@ s32 texDPTextureSimple(Gfx** gdl, Texture* tex, s32 renderFlags, s32 frameOption
                 }
             }
             temp_v1 = (tex->flags & ~(RENDER_TEX_BLEND | RENDER_MIPMAPS));
-            renderFlags = temp_v1 | renderFlags;
+            renderFlags |= temp_v1;
             if ((basetex != gCurrTex0) || (blendtex != gCurrTex1) || (force != 0)) {
                 gCurrTex0 = basetex;
                 gCurrTex1 = blendtex;
@@ -1290,7 +1287,7 @@ s32 texDPTextureSimple(Gfx** gdl, Texture* tex, s32 renderFlags, s32 frameOption
         var_a0 = 0;
         if (tex != NULL) {
             temp_v1 = (tex->flags & ~(RENDER_TEX_BLEND | RENDER_MIPMAPS));
-            renderFlags = temp_v1 | renderFlags;
+            renderFlags |= temp_v1;
             var_a0 = 1;
             var_a3_2 = pointersIntsArray;
             hasPalette = TEX_FORMAT(tex->format) == TEX_FORMAT_CI4;
@@ -1318,7 +1315,7 @@ s32 texDPTextureSimple(Gfx** gdl, Texture* tex, s32 renderFlags, s32 frameOption
                 temp = 37;
             } else if (renderFlags & RENDER_SUBSURFACE) {
                 if (renderMipmaps != 0) {
-                    temp = 49;
+                    temp = 33;
                 } else {
                     temp += 24;
                 }
@@ -1369,7 +1366,6 @@ s32 texDPTextureSimple(Gfx** gdl, Texture* tex, s32 renderFlags, s32 frameOption
     *gdl = dl;
     return 0;
 }
-#endif
 
 #ifndef NON_EQUIVALENT
 #pragma GLOBAL_ASM("asm/nonmatchings/texture/texDPTextures.s")

--- a/src/texture.c
+++ b/src/texture.c
@@ -796,10 +796,6 @@ Texture *texLoadTexture(s32 id) {
 static const char str_8009a370[] = "Error: Texture no %d out of range on load -> max=%d.!!\n";
 static const char str_8009a3a8[] = "Multiple texture fail!!\n";
 // official name: texLoadTexture
-#ifndef NON_MATCHING
-#pragma GLOBAL_ASM("asm/nonmatchings/texture/texLoadTextureActual.s")
-#else
-// https://decomp.me/scratch/ht6r3
 Texture* texLoadTextureActual(s32 id, u8 param2) {
     u32 binFileID; // sp74
     Texture* tex;
@@ -831,16 +827,18 @@ Texture* texLoadTextureActual(s32 id, u8 param2) {
     } else {
         id = gFile_TEXTABLE[id];
     }
-    tabEntry = id & 0xFFFF;
-    if (tabEntry & 0x8000) {
-        tab = 1; // TEX1
+    id &= 0xFFFF;
+    tabEntry = id;
+    if (id & 0x8000) {
+        tab = 1;
         binFileID = TEX1_BIN;
-        tabEntry &= 0x7FFF;
+        tabEntry = id & 0x7FFF;
     } else {
-        tab = 0; // TEX0
+        tab = 0;
         binFileID = TEX0_BIN;
     }
     
+    if ((tab * 4) + tabEntry + tabEntry) {}
     offset = gFile_TEX_TAB[tab][tabEntry] & 0xFFFFFF;
     numFrames = (gFile_TEX_TAB[tab][tabEntry] >> 24) & 0xFF;
     compressedSize = (gFile_TEX_TAB[tab][tabEntry + 1] & 0xFFFFFF) - offset;
@@ -905,8 +903,6 @@ Texture* texLoadTextureActual(s32 id, u8 param2) {
     }
     return firstTex;
 }
-#endif
-
 static const char str_8009a3c4[] = "TEX Error: TexTab overflow %d,%d!!\n";
 
 Gfx *texSetupDisplayLists(Texture *texture, Gfx *gdl) {


### PR DESCRIPTION
Six more core functions, which finishes off `src/rarezip.c`.

- `rarezipUncompress` (official name `rzipUncompress`)
- `texDPTextureSimple`
- `texLoadTextureActual` (official name `texLoadTexture`)
- `modLoadAnimActual`
- `blockSetupVertices`
- `objprint_func_80036890`

A few things worth a look:
- `blockSetupVertices` was checking `RENDER_UNK10` where the asm's `lui` says `RENDER_DECAL`, so that's corrected. The `inx`/`inz` encodes now also carry the same `& 0x3fff` mask that `iny` already had.
- `texDPTextureSimple` had the mipmap count in the `RENDER_SUBSURFACE` branch as 49, but the machine code says 33.
- `objprint_func_80036890` returns `s32` rather than `void` - it's a K&R definition with an implicit int return type, and neither call site uses the value.
- `rarezipUncompress` needs a handful of `// fake match` reads, and keeps its empty comparisons against the end of the output buffer. There are three unreferenced overflow warning strings in rodata right above it, so presumably there was an overflow check compiled out of the original.

That puts core at 1744/1748 (99.77%). ROM still matches (`dino.py build` -> `build/dino.z64: OK`), and `--all-code` builds.
