### PR TITLE
More DLL matches

### DIFF
--- a/src/dlls/engine/14_modgfx/modgfx.c
+++ b/src/dlls/engine/14_modgfx/modgfx.c
@@ -125,6 +125,7 @@ typedef struct {
 /*0x0*/ static const char str_0[] = "warning in modgfx dll no spare memory available\n";
 
 static void dll_14_func_4C0C(s16 arg0, s32 arg1);
+s32 dll_14_func_F4(ModgfxStruct* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5, s32 arg6, s32 arg7);
 static void dll_14_func_4EDC(ModgfxInstance* arg0, u8 arg1);
 
 // offset: 0x0 | ctor
@@ -939,7 +940,27 @@ void dll_14_func_6DE4(void* arg0) {
 }
 
 // offset: 0x6E24 | func: 35 | export: 19
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6E24.s")
+void dll_14_func_6E24(Object* arg0, s32 arg1, s32 arg2, s32 arg3, s32 arg4, s32 arg5, s32 arg6) {
+    bss_AD0.unk0 = bss_7C0;
+    bss_AD0.unk5D = bss_AC4 - bss_AC0;
+    if ((arg6 == 0) && (arg5 == 0)) {
+        bss_AD0.unk54 |= 0x2000000;
+    } else {
+        bss_AD0.unk54 |= 0x4000000;
+    }
+    if (bss_AD0.unk54 & 1) {
+        if (bss_AD0.unk4 != NULL) {
+            bss_AD0.unk2C.x += bss_AD0.unk4->globalPosition.x;
+            bss_AD0.unk2C.y += bss_AD0.unk4->globalPosition.y;
+            bss_AD0.unk2C.z += bss_AD0.unk4->globalPosition.z;
+        } else {
+            bss_AD0.unk2C.x += arg0->srt.transl.x;
+            bss_AD0.unk2C.y += arg0->srt.transl.y;
+            bss_AD0.unk2C.z += arg0->srt.transl.z;
+        }
+    }
+    data_2C = dll_14_func_F4(&bss_AD0, 0, arg2, arg1, arg4, arg3, arg5, arg6);
+}
 
 // offset: 0x6F88 | func: 36 | export: 20
 void dll_14_func_6F88(s32 arg0) {

--- a/src/dlls/engine/14_modgfx/modgfx.c
+++ b/src/dlls/engine/14_modgfx/modgfx.c
@@ -863,9 +863,18 @@ void dll_14_func_4EDC(ModgfxInstance* arg0, u8 arg1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_5E50.s")
 
 // offset: 0x5FFC | func: 22
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_5FFC.s")
+void dll_14_func_5FFC(ModgfxInstance* arg0, BSS0_9C* arg1, s32 arg2, s32 arg3) {
+    arg0->unk24[0].x += arg1->unk4 * data_C;
+    arg0->unk24[0].y += arg1->unk8 * data_C;
+    arg0->unk24[0].z += arg1->unkC * data_C;
+}
 
 // offset: 0x6068 | func: 23
+// blocked: register-allocation residual (18 words, 13/18 diffs are register-class
+// only; best source form found reads/writes unk106,unk108,unk10A via
+// arg0->unkXXX += (s32|s16)(arg1->unkY * data_C) triples with BSS0_9C* arg1 --
+// target hoists 2 of 3 field reads ahead of the float ops, candidate schedules
+// them just-in-time; could not find a source form reproducing that schedule.
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6068.s")
 
 // offset: 0x6100 | func: 24

--- a/src/dlls/engine/14_modgfx/modgfx.c
+++ b/src/dlls/engine/14_modgfx/modgfx.c
@@ -16,15 +16,9 @@ typedef struct {
     s32 unk3C;
     s32 unk40;
     s16 unk44;
-    s16 unk46;
-    s16 unk48;
-    s16 unk4A;
-    s16 unk4C;
-    s16 unk4E;
-    s16 unk50;
-    s16 unk52;
+    s16 unk46[7];
     s32 unk54;
-    u8 _unk58;
+    u8 unk58;
     u8 unk59;
     u8 unk5A;
     u8 unk5B;
@@ -36,7 +30,8 @@ typedef struct {
 typedef struct {
     s32 unk0;
     f32 unk4;
-    u8 _unk8[0x10 - 0x8];
+    f32 unk8;
+    f32 unkC;
     s32 unk10;
     s16 unk14;
     u8 unk16;
@@ -121,14 +116,11 @@ typedef struct {
 /*0x10*/ static f32 data_10 = 0.0;
 
 /*0x0*/ static ModgfxInstance* bss_0[496];
-/*0x7C0*/ static u8 bss_7C0[0x300];
-/*0xAC0*/ static u8 bss_AC0[0x4];
-/*0xAC4*/ static u8 bss_AC4[0x4];
-/*0xAC8*/ static u8 bss_AC8[0x8];
-/*0xAD0*/ static u8 bss_AD0[0x46];
-/*0xB16*/ static u8 bss_B16[0x2];
-/*0xB18*/ static u8 _bss_B18[0x8];
-/*0xB20*/ static u8 _bss_B20[0x10];
+/*0x7C0*/ static BSS0_9C bss_7C0[32];
+/*0xAC0*/ static BSS0_9C* bss_AC0;
+/*0xAC4*/ static BSS0_9C* bss_AC4;
+/*0xAC8*/ static s16 bss_AC8[4];
+/*0xAD0*/ static ModgfxStruct bss_AD0;
 
 /*0x0*/ static const char str_0[] = "warning in modgfx dll no spare memory available\n";
 
@@ -886,31 +878,71 @@ void dll_14_func_4EDC(ModgfxInstance* arg0, u8 arg1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6758.s")
 
 // offset: 0x6BE8 | func: 28 | export: 12
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6BE8.s")
+void dll_14_func_6BE8(Object* arg0, u8 arg1, u8 arg2, s32 arg3, s32 arg4) {
+    bzero(&bss_AD0, sizeof(bss_AD0));
+    bss_AD0.unk5A = 0;
+    bss_AD0.unk5B = 0;
+    bss_AD0.unk58 = arg1;
+    bss_AD0.unk44 = arg1;
+    bss_AD0.unk2C.x = 0.0f;
+    bss_AD0.unk2C.y = 0.0f;
+    bss_AD0.unk2C.z = 0.0f;
+    bss_AD0.unk20 = 0.0f;
+    bss_AD0.unk24 = 0.0f;
+    bss_AD0.unk28 = 0.0f;
+    bss_AD0.unk4 = arg0;
+    bss_AD0.unk38 = 1.0f;
+    bss_AD0.unk40 = arg3;
+    bss_AD0.unk3C = arg4;
+    bss_AD0.unk59 = arg2;
+}
 
 // offset: 0x6CA0 | func: 29 | export: 13
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6CA0.s")
+void dll_14_func_6CA0(void) {
+    bss_AC0 = bss_7C0;
+    bss_AC4 = bss_AC0;
+    bss_AC8[0] = 0;
+}
 
 // offset: 0x6CD8 | func: 30 | export: 14
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6CD8.s")
+void dll_14_func_6CD8(s32 arg0, f32 arg1, f32 arg2, f32 arg3, s16 arg4, s32 arg5) {
+    bss_AC4->unk16 = bss_AC8[0];
+    bss_AC4->unk14 = arg4;
+    bss_AC4->unk10 = arg5;
+    bss_AC4->unk0 = arg0;
+    bss_AC4->unk4 = arg1;
+    bss_AC4->unk8 = arg2;
+    bss_AC4->unkC = arg3;
+    bss_AC4++;
+}
 
 // offset: 0x6D58 | func: 31 | export: 15
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6D58.s")
+void dll_14_func_6D58(void) {
+    bss_AC8[0]++;
+}
 
 // offset: 0x6D80 | func: 32 | export: 16
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6D80.s")
+void dll_14_func_6D80(s16 arg0) {
+    bss_AC8[0] = arg0;
+}
 
 // offset: 0x6DA8 | func: 33 | export: 17
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6DA8.s")
+void dll_14_func_6DA8(s16 arg0) {
+    bss_AD0.unk46[bss_AC8[0]] = arg0;
+}
 
 // offset: 0x6DE4 | func: 34 | export: 18
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6DE4.s")
+void dll_14_func_6DE4(void* arg0) {
+    bcopy(arg0, bss_AD0.unk46, sizeof(bss_AD0.unk46));
+}
 
 // offset: 0x6E24 | func: 35 | export: 19
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6E24.s")
 
 // offset: 0x6F88 | func: 36 | export: 20
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_6F88.s")
+void dll_14_func_6F88(s32 arg0) {
+    bss_AD0.unk54 |= arg0;
+}
 
 // offset: 0x6FB0 | func: 37 | export: 21
 s16 dll_14_func_6FB0(void) {

--- a/src/dlls/engine/14_modgfx/modgfx.c
+++ b/src/dlls/engine/14_modgfx/modgfx.c
@@ -111,7 +111,7 @@ typedef struct {
 
 /*0x0*/ static u32 data_0 = 0x00000000;
 /*0x4*/ static u32 data_4 = 0x00000000;
-/*0x8*/ static u32 data_8 = 0x00000000;
+/*0x8*/ static u8 data_8 = 0;
 /*0xC*/ static f32 data_C = 0.0;
 /*0x10*/ static f32 data_10 = 0.0;
 
@@ -730,7 +730,9 @@ static s16 data_2C = 0;
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_4854.s")
 
 // offset: 0x4910 | func: 8 | export: 8
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_4910.s")
+void dll_14_func_4910(void) {
+    data_8++;
+}
 
 // offset: 0x4938 | func: 9 | export: 9
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/14_modgfx/dll_14_func_4938.s")

--- a/src/dlls/engine/32_modelfx/modelfx.c
+++ b/src/dlls/engine/32_modelfx/modelfx.c
@@ -536,10 +536,12 @@ void dll_32_dtor(void *dll);
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/32_modelfx/dll_32_dtor.s")
 
 // offset: 0x2C8 | func: 0 | export: 0
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/32_modelfx/dll_32_func_2C8.s")
+void dll_32_func_2C8(void) {
+}
 
 // offset: 0x2D0 | func: 1 | export: 1
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/32_modelfx/dll_32_func_2D0.s")
+void dll_32_func_2D0(s32 arg0) {
+}
 
 // offset: 0x2DC | func: 2 | export: 2
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/32_modelfx/dll_32_func_2DC.s")

--- a/src/dlls/engine/7_newday/newday.c
+++ b/src/dlls/engine/7_newday/newday.c
@@ -1,3 +1,4 @@
+#include "sys/main.h"
 #include "sys/gfx/texture.h"
 #include "dlls/engine/7_newday.h"
 
@@ -134,10 +135,10 @@ typedef struct
 /*0CC*/ UNK_TYPE_32 unkCC;
 /*0D0*/ UNK_TYPE_32 unkD0;
 /*0D4*/ u8 _unkD4[8];
-/*0DC*/ UNK_TYPE_32 unkDC;
+/*0DC*/ s32 unkDC;
 /*0E0*/ UNK_TYPE_32 unkE0;
 /*0E4*/ s32 unkE4;
-/*0E8*/ UNK_TYPE_32 unkE8;
+/*0E8*/ s32 unkE8;
 /*0EC*/ UNK_TYPE_32 unkEC;
 /*0F0*/ UNK_TYPE_32 unkF0;
 /*0F4*/ UNK_TYPE_32 unkF4;
@@ -154,9 +155,26 @@ typedef struct
 /*115*/ u8 _unk115[3];
 } NewDayStruct;
 
-/*0x0*/ static u8 _bss_0[0x26]; // DAT_810296a0
-/*0x26*/ static u8 _bss_26; // DAT_810296c6
-/*0x27*/ static u8 _bss_27; // DAT_810296c7
+// size: 0x28
+typedef struct {
+/*0x00*/ s32 unk0;
+/*0x04*/ s32 unk4;
+/*0x08*/ s32 unk8;
+/*0x0C*/ s32 unkC;
+/*0x10*/ s32 unk10;
+/*0x14*/ s32 unk14;
+/*0x18*/ u16 unk18;
+/*0x1A*/ u16 unk1A;
+/*0x1C*/ u16 unk1C;
+/*0x1E*/ u16 unk1E;
+/*0x20*/ u16 unk20;
+/*0x22*/ u16 unk22;
+/*0x24*/ u8 _unk24[2];
+/*0x26*/ u8 unk26;
+/*0x27*/ u8 unk27;
+} NewDayBss;
+
+/*0x0*/ static NewDayBss _bss_0; // DAT_810296a0
 /*0x28*/ static u8 _bss_28[0x4]; // DAT_810296c8
 /*0x2C*/ static u8 _bss_2C[0x4]; // DAT_810296cc
 /*0x30*/ static NewDayStruct *_bss_30; // PTR_810296d0
@@ -192,11 +210,21 @@ void dll_7_func_CDC(f32* timeSeconds) {
 }
 
 // offset: 0xD08 | func: 5 | export: 5
-void dll_7_func_D08(f32* arg0);
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_D08.s")
+void dll_7_func_D08(f32* arg0) {
+    if (_bss_30 != NULL) {
+        *arg0 = _bss_30->unkDC;
+    } else {
+        *arg0 = 0.0f;
+    }
+}
 
 // offset: 0xD50 | func: 6 | export: 6
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_D50.s")
+void dll_7_func_D50(f32 arg0) {
+    if (_bss_30 != NULL) {
+        _bss_30->unkDC = arg0;
+        _bss_30->unkC4 = _bss_30->unkDC / 60.0f;
+    }
+}
 
 // offset: 0xDAC | func: 7 | export: 7
 void dll_7_func_DAC(s32 *param1) {
@@ -275,15 +303,29 @@ void dll_7_convert_ticks_to_real_time(f32 ticksF, s16 *hours, s16 *minutes, s16 
 }
 
 // offset: 0xFFC | func: 12 | export: 12
-s32 dll_7_func_FFC(void);
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_FFC.s")
+s32 dll_7_func_FFC(void) {
+    if (_bss_30 != NULL) {
+        return _bss_30->unkE8;
+    }
+    return 0;
+}
 
 // offset: 0x102C | func: 13 | export: 13
 void dll_7_func_102C(Gfx **gdl, Mtx **arg1);
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_102C.s")
 
 // offset: 0x20D4 | func: 14 | export: 14
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_20D4.s")
+void dll_7_func_20D4(u8* arg0, u8* arg1, u8* arg2) {
+    if (_bss_30 != NULL) {
+        *arg0 = _data_34;
+        *arg1 = _data_38;
+        *arg2 = _data_3C;
+    } else {
+        *arg0 = 0xFF;
+        *arg1 = 0xFF;
+        *arg2 = 0xFF;
+    }
+}
 
 // offset: 0x2130 | func: 15 | export: 15
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_2130.s")
@@ -310,34 +352,62 @@ void dll_7_func_102C(Gfx **gdl, Mtx **arg1);
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_56F8.s")
 
 // offset: 0x57C0 | func: 23
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_57C0.s")
+void dll_7_func_57C0(void) {
+    bzero(&_bss_0, sizeof(_bss_0));
+    _bss_0.unk26 = mainGetBits(0x2BA);
+}
 
 // offset: 0x5818 | func: 24
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_5818.s")
 
 // offset: 0x5D20 | func: 25 | export: 16
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_5D20.s")
+void dll_7_func_5D20(u8 arg0) {
+    _bss_0.unk27 &= 0xFFF0;
+    _bss_0.unk27 |= arg0 & 0xF;
+    _bss_0.unk27 |= 0x10;
+}
 
 // offset: 0x5D6C | func: 26 | export: 17
 s32 dll_7_func_5D6C(void) {
-    return _bss_27 & 0xF;
+    return _bss_0.unk27 & 0xF;
 }
 
 // offset: 0x5D90 | func: 27 | export: 18
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_5D90.s")
+void dll_7_func_5D90(s32 arg0, s32 arg1, s32 arg2, s32 arg3) {
+    _bss_0.unkC = arg0;
+    _bss_0.unk0 = arg1;
+    _bss_0.unk8 = arg2;
+    _bss_0.unk4 = arg3;
+}
 
 // offset: 0x5DBC | func: 28 | export: 19
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_5DBC.s")
+void dll_7_func_5DBC(s32 arg0, s32 arg1, u16 arg2, u16 arg3) {
+    _bss_0.unk10 = arg0;
+    _bss_0.unk14 = arg1;
+    _bss_0.unk18 = arg2;
+    _bss_0.unk1A = arg3;
+}
 
 // offset: 0x5E00 | func: 29 | export: 20
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_5E00.s")
+void dll_7_func_5E00(u16 arg0, u16 arg1, u16 arg2, u16 arg3) {
+    _bss_0.unk1C = arg0;
+    _bss_0.unk1E = arg1;
+    _bss_0.unk20 = arg2;
+    _bss_0.unk22 = arg3;
+}
 
 // offset: 0x5E5C | func: 30 | export: 21
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/engine/7_newday/dll_7_func_5E5C.s")
+void dll_7_func_5E5C(u8 arg0) {
+    if (arg0 >= 0x1C) {
+        arg0 = 0;
+    }
+    _bss_0.unk26 = arg0;
+    mainSetBits(0x2BA, arg0);
+}
 
 // offset: 0x5EB4 | func: 31 | export: 22
 u8 dll_7_func_5EB4(void) {
-    return _bss_26;
+    return _bss_0.unk26;
 }
 
 // offset: 0x5ED0 | func: 32 | export: 23

--- a/src/dlls/objects/615_crawler/crawler.c
+++ b/src/dlls/objects/615_crawler/crawler.c
@@ -4,7 +4,9 @@
 //Used by Skeetlas/Scorpions
 
 typedef struct {
-    u8 _unk0[0x298];
+    u8 _unk0[0x292];
+    u8 unk292;
+    u8 _unk293[0x298 - 0x293];
 } DLL615_Data;
 
 /*0x0*/ static u32 _data_0[] = {
@@ -57,7 +59,12 @@ u32 dll_615_get_data_size(Object *self, u32 a1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/615_crawler/dll_615_func_19FC.s")
 
 // offset: 0x1AC8 | func: 8
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/615_crawler/dll_615_func_1AC8.s")
+s32 dll_615_func_1AC8(Object* self, s32 arg1, s32 arg2) {
+    DLL615_Data* data = self->data;
+
+    data->unk292 = 1;
+    return 0;
+}
 
 // offset: 0x1AE8 | func: 9
 void dll_615_func_1AE8(Object* self) {

--- a/src/dlls/objects/714_DR_CloudRunner/DRcloudrunner.c
+++ b/src/dlls/objects/714_DR_CloudRunner/DRcloudrunner.c
@@ -5,6 +5,10 @@
 #include "sys/gfx/model.h"
 #include "sys/rand.h"
 #include "sys/main.h"
+#include "sys/objects.h"
+#include "sys/math.h"
+#include "sys/intersect.h"
+#include "dlls/engine/29_gplay.h"
 #include "dll.h"
 
 #include "dlls/objects/745_DR_Cage.h"
@@ -146,7 +150,10 @@ void dll_714_func_3280(Object* self, s32 arg1, DRCloudRunner_Data* objdata);
 /*0x30*/ static u8 _bss_30[0x40];
 
 // offset: 0x0 | func: 0
-// Needs dll_714_func_1B20/1C6C/1DE0/2E0C/303C/31CC to be decompiled (static) to match
+// Needs dll_714_func_1B20/1C6C/1DE0/2E0C/303C/31CC to be decompiled (static) to match.
+// NOTE: only add `static` to those callees in the SAME edit that decompiles this
+// function. IDO -O2 discards the body of a static function that has no C-level
+// caller in the TU (a GLOBAL_ASM caller does not count), leaving `jr ra; nop`.
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_0.s")
 
 // offset: 0x8C | ctor
@@ -166,7 +173,13 @@ void dll_714_control(Object *self);
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_control.s")
 
 // offset: 0x85C | func: 3
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_85C.s")
+void dll_714_func_85C(Object* self) {
+    Object* player = objGetPlayer();
+
+    if (vec3DistanceXZ(&player->globalPosition, &self->globalPosition) > 600.0f) {
+        gDLL_29_Gplay->vtbl->set_obj_group_status(self->mapID, 12, 0);
+    }
+}
 
 // offset: 0x8F8 | func: 4
 void dll_714_func_8F8(Object* self) {
@@ -384,7 +397,21 @@ s32 dll_714_func_1968(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_303C.s")
 
 // offset: 0x31CC | func: 33
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_31CC.s")
+s32 dll_714_func_31CC(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
+    DRCloudRunner_Data* data = self->data;
+    s32 opacity;
+
+    if (data->unk910 == 0) {
+        opacity = self->opacity;
+        opacity -= gUpdateRate;
+        if (opacity < 0) {
+            gDLL_29_Gplay->vtbl->set_obj_group_status(self->mapID, 12, 0);
+        }
+        self->opacity = opacity;
+    }
+
+    return 0;
+}
 
 // offset: 0x3268 | func: 34
 s32 dll_714_func_3268(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
@@ -402,7 +429,18 @@ void dll_714_func_3560(s32 arg0, s32 arg1, s32 arg2) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_3574.s")
 
 // offset: 0x37F4 | func: 38
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_37F4.s")
+void dll_714_func_37F4(Object* self, s32 arg1) {
+    DRCloudRunner_Setup* setup = objAllocSetup(0x2C, 0xD4);
+
+    setup->base.loadFlags = 2;
+    setup->base.x = self->srt.transl.x;
+    setup->base.y = self->srt.transl.y;
+    setup->base.z = self->srt.transl.z;
+    setup->unk1A = arg1;
+    setup->unk1C = 0;
+    setup->unk1E = -1;
+    objSetupObject(&setup->base, 5, self->mapID, -1, self->parent);
+}
 
 // offset: 0x38A0 | func: 39
 // Needs dll_714_func_3280 to be decompiled (static) to match

--- a/src/dlls/objects/714_DR_CloudRunner/DRcloudrunner.c
+++ b/src/dlls/objects/714_DR_CloudRunner/DRcloudrunner.c
@@ -16,9 +16,28 @@ s8 unk4[0x25B - 0x4];
 s8 unk25B;
 s8 unk25C[0x272 - 0x25C];
 s8 unk272;
-s8 unk273[0x910 - 0x273];
+s8 unk273[0x278 - 0x273];
+f32 unk278;
+f32 unk27C;
+s8 unk280[0x28C - 0x280];
+f32 unk28C;
+s8 unk290[0x308 - 0x290];
+s32 unk308;
+s8 unk30C[0x34C - 0x30C];
+s8 unk34C;
+s8 unk34D[0x86C - 0x34D];
+f32 unk86C;
+f32 unk870;
+f32 unk874;
+s8 unk878[0x910 - 0x878];
 s16 unk910;
-s8 unk912[0x920 - 0x912];
+s8 unk912;
+s8 unk913;
+u8 unk914;
+s8 unk915[0x917 - 0x915];
+u8 unk917;
+u8 unk918;
+s8 unk919[0x920 - 0x919];
 u8 unk920;
 } DRCloudRunner_Data;
 
@@ -29,6 +48,19 @@ s16 unk1A;
 s16 unk1C;
 s16 unk1E;
 } DRCloudRunner_Setup;
+
+typedef s32 (*DRCloudRunner_StateCallback)(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+
+s32 dll_714_func_18E0(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_1968(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_1B20(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_1C6C(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_1DE0(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_2E0C(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_303C(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_31CC(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+s32 dll_714_func_3268(Object* self, DRCloudRunner_Data* objdata, s32 arg2);
+void dll_714_func_3280(Object* self, s32 arg1, DRCloudRunner_Data* objdata);
 
 /*0x0*/ static u16 _data_0[] = {
     0x091d, 0x091e, 0x091f, 0x0000
@@ -108,15 +140,17 @@ s16 unk1E;
 };
 /*0x15C*/ static u32 _data_15C = 0x00010101;
 
-/*0x0*/ static u8 _bss_0[0x20];
-/*0x20*/ static u8 _bss_20[0x8];
+/*0x0*/ static DRCloudRunner_StateCallback _bss_0[8];
+/*0x20*/ static DRCloudRunner_StateCallback _bss_20[2];
 /*0x28*/ static u8 _bss_28[0x8];
 /*0x30*/ static u8 _bss_30[0x40];
 
 // offset: 0x0 | func: 0
+// Needs dll_714_func_1B20/1C6C/1DE0/2E0C/303C/31CC to be decompiled (static) to match
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_0.s")
 
 // offset: 0x8C | ctor
+// Needs dll_714_func_0 to be decompiled (static) to match
 void dll_714_ctor(void *dll);
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_ctor.s")
 
@@ -135,7 +169,17 @@ void dll_714_control(Object *self);
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_85C.s")
 
 // offset: 0x8F8 | func: 4
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_8F8.s")
+void dll_714_func_8F8(Object* self) {
+    ObjectShadow* shadow = self->shadow;
+    f32 height;
+
+    height = 0.0f;
+    shadow->tr.x = self->srt.transl.x;
+    shadow->tr.z = self->srt.transl.z;
+    if (trackGetHeightFloor(self, self->srt.transl.x, self->srt.transl.y, self->srt.transl.z, &height, 0)) {
+        shadow->tr.y = self->srt.transl.y - height;
+    }
+}
 
 // offset: 0x984 | func: 5
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_984.s")
@@ -166,37 +210,86 @@ u32 dll_714_get_data_size(Object *self, u32 a1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_F74.s")
 
 // offset: 0x10BC | func: 12 | export: 8
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_10BC.s")
+s32 dll_714_func_10BC(Object* self) {
+    DRCloudRunner_Data* objdata = self->data;
+    s32 ret;
+
+    if (objdata->unk918 != 0) {
+        ret = 1;
+    } else {
+        ret = 2;
+    }
+    return ret;
+}
 
 // offset: 0x10E4 | func: 13 | export: 9
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_10E4.s")
+void dll_714_func_10E4(Object* self, f32* arg1, f32* arg2, f32* arg3) {
+    DRCloudRunner_Data* objdata = self->data;
+
+    *arg1 = objdata->unk86C;
+    *arg2 = objdata->unk870;
+    *arg3 = objdata->unk874;
+}
 
 // offset: 0x1108 | func: 14 | export: 10
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_1108.s")
 
 // offset: 0x1318 | func: 15 | export: 11
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_1318.s")
+s32 dll_714_func_1318(Object* self) {
+    DRCloudRunner_Data* objdata = self->data;
+    s32 ret;
+
+    if (objdata->unk917 != 0) {
+        ret = 2;
+    } else {
+        ret = 1;
+    }
+    return ret;
+}
 
 // offset: 0x1340 | func: 16 | export: 12
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_1340.s")
 
 // offset: 0x1404 | func: 17 | export: 13
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_1404.s")
+s32 dll_714_func_1404(Object* self) {
+    return 0;
+}
 
 // offset: 0x1414 | func: 18 | export: 14
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_1414.s")
+void dll_714_func_1414(Object* self, s32 arg1) {
+    DRCloudRunner_Data* objdata = self->data;
+
+    objdata->unk912 = arg1;
+    if (arg1 == 1) {
+        objdata->unk34C = 0;
+        if (self->seqSlot != -1) {
+            gDLL_3_Animation->vtbl->end_obj_sequence(self->seqSlot);
+        }
+    } else {
+        objdata->unk34C = 1;
+    }
+}
 
 // offset: 0x1488 | func: 19 | export: 15
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_1488.s")
+void dll_714_func_1488(Object* self, f32* arg1, s32* arg2) {
+    *arg1 = 0.0f;
+    *arg2 = 0;
+}
 
 // offset: 0x14B0 | func: 20 | export: 16
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_14B0.s")
+f32 dll_714_func_14B0(Object* self, f32* arg1) {
+    *arg1 = 5.0f;
+    return 0.0f;
+}
 
 // offset: 0x14D8 | func: 21 | export: 17
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_14D8.s")
+s32 dll_714_func_14D8(Object* self) {
+    return 0;
+}
 
 // offset: 0x14E8 | func: 22 | export: 18
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_14E8.s")
+void dll_714_func_14E8(Object* self) {
+}
 
 // offset: 0x14F4 | func: 23 | export: 19
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_14F4.s")
@@ -205,10 +298,29 @@ u32 dll_714_get_data_size(Object *self, u32 a1) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_15E8.s")
 
 // offset: 0x18AC | func: 25
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_18AC.s")
+void dll_714_func_18AC(Object* self, DRCloudRunner_Data* objdata) {
+    objdata->unk28C = 0.0f;
+    objdata->unk27C = 0.0f;
+    objdata->unk278 = 0.0f;
+    self->velocity.x = 0.0f;
+    self->velocity.y = 0.0f;
+    self->velocity.z = 0.0f;
+}
 
 // offset: 0x18E0 | func: 26
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_18E0.s")
+s32 dll_714_func_18E0(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
+    DRCloudRunner_Data* data = self->data;
+    u32 new_var;
+
+    if (data->unk914 == 0) {
+        return 2;
+    }
+
+    func_8002674C(self);
+    new_var = 4;
+    data->unk920 = (((new_var * ((data->unk910 > 0) & 1)) * 4) & 0x10) | (data->unk920 & 0xFFEF);
+    return 3;
+}
 
 // offset: 0x1968 | func: 27
 s32 dll_714_func_1968(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
@@ -275,13 +387,16 @@ s32 dll_714_func_1968(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_31CC.s")
 
 // offset: 0x3268 | func: 34
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_3268.s")
+s32 dll_714_func_3268(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
+    return 0;
+}
 
 // offset: 0x3280 | func: 35
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_3280.s")
 
 // offset: 0x3560 | func: 36 | export: 20
-#pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_3560.s")
+void dll_714_func_3560(s32 arg0, s32 arg1, s32 arg2) {
+}
 
 // offset: 0x3574 | func: 37
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_3574.s")
@@ -290,4 +405,5 @@ s32 dll_714_func_1968(Object* self, DRCloudRunner_Data* objdata, s32 arg2) {
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_37F4.s")
 
 // offset: 0x38A0 | func: 39
+// Needs dll_714_func_3280 to be decompiled (static) to match
 #pragma GLOBAL_ASM("asm/nonmatchings/dlls/objects/714_DR_CloudRunner/dll_714_func_38A0.s")


### PR DESCRIPTION
41 more DLL functions, mostly in modgfx and DR_CloudRunner. No core changes.

**DLLs matched:**
- 32 modelfx: `dll_32_func_2C8`, `dll_32_func_2D0`

**DLL progress:**
- 7 newday: `dll_7_func_D08`, `D50`, `FFC`, `20D4`, `57C0`, `5D20`, `5D90`, `5DBC`, `5E00`, `5E5C`
- 14 modgfx: `dll_14_func_4910`, `5FFC`, `6BE8`, `6CA0`, `6CD8`, `6D58`, `6D80`, `6DA8`, `6DE4`, `6E24`, `6F88`
- 615 crawler: `dll_615_func_1AC8`
- 714 DR_CloudRunner: `dll_714_func_85C`, `8F8`, `10BC`, `10E4`, `1318`, `1404`, `1414`, `1488`, `14B0`, `14D8`, `14E8`, `18AC`, `18E0`, `31CC`, `3268`, `3560`, `37F4`

Most of these only match once the data they touch is typed, so there's some struct work in here too:
- modgfx: the bss run at 0xAC0-0xB30 is now typed with the DLL's existing `BSS0_9C` and `ModgfxStruct` types - `bss_7C0` is a `BSS0_9C[32]` ring buffer with `bss_AC0`/`bss_AC4` pointing into it. `data_8` also had to be narrowed from `u32` to `u8` for `dll_14_func_4910`.
- newday: the 0x28-byte bss block is a `NewDayBss` struct now.
- DR_CloudRunner: named some fields in the previously opaque 0x273-0x910 range of `DRCloudRunner_Data`, plus a typedef for the two state handler tables in bss.
- crawler: one flag byte (`unk292`) carved out of the existing padding.

That puts DLLs at 5805/9263 (62.67%). ROM still matches (`dino.py build` -> `build/dino.z64: OK`), and `--all-code` builds.
